### PR TITLE
某些环境下 navigator.language 获取的值 为 zh-cn 全小写的情况~

### DIFF
--- a/src/locales/index.js
+++ b/src/locales/index.js
@@ -47,6 +47,7 @@ const dateTimeFormats = {
 }
 
 let locale = get_item('_locale') || navigator.language;
+locale = locale.split('-')[0].toLowerCase() + '-' + locale.split('-')[1].toUpperCase();
 set_item('_locale', locale)
 
 export default new VueI18n({


### PR DESCRIPTION
某些环境下 navigator.language 获取的值 为 zh-cn 全小写的情况~
那么钱包的语言调取的时候为英文，但右上角的图标为 中文的国旗(因为src调取的时候 toUpperCase 了)
某些环境：例如ios9