### PR TITLE
fix transfer balance tip

### DIFF
--- a/src/components/Transfer.vue
+++ b/src/components/Transfer.vue
@@ -133,6 +133,7 @@
             },
             currentWallet () {
                 this.error.other = '';
+                this.fetch_balance();
             }
         },
         mounted () {


### PR DESCRIPTION
转账页面，切换账户的时候，余额的显示没有跟随账户的切换进行更新。